### PR TITLE
Fix: ループが高速で回り続ける問題を修正

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -256,7 +256,7 @@ impl EventHandler for Handler {
                         };
                     }
                     save_cache(&new_cache);
-                }
+                };
                 tokio::time::sleep(tokio::time::Duration::from_secs(300)).await;
             }
         });


### PR DESCRIPTION
指定した時間に達した瞬間、main.rs: 260行目を飛ばしてループし続けるようで、githubのrate limitに一瞬で達してしまうので修正