### PR TITLE
ログを追加&Log実装を変更

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,55 +42,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
-dependencies = [
- "anstyle",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,12 +207,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colorchoice"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,29 +361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "humantime",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +390,15 @@ name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
+name = "fern"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f0c14694cbd524c8720dd69b0e3179344f04ebb5f90f2e4a440c6ea3b2f1ee"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "flate2"
@@ -747,12 +678,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,12 +842,6 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -2210,12 +2129,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2232,7 +2145,7 @@ name = "vrc_research_bot"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "env_logger",
+ "fern",
  "log",
  "poise",
  "reqwest 0.12.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ serde_json = { version = "1.0.125" }
 serde_derive = { version = "1.0.208" }
 reqwest = "0.12.5"
 log = { version = "0.4.22" }
-env_logger = { version = "0.11.5" }
+fern = { version = "0.6.2" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,14 +263,34 @@ impl EventHandler for Handler {
     }
 }
 
+fn init_logger() {
+    let base_conf = fern::Dispatch::new()
+        .level(log::LevelFilter::Warn)
+        .format(|out, message, record| {
+            out.finish(format_args!(
+                "[{} {} {}]: {}",
+                chrono::Local::now().format("%Y-%m-%dT%H:%M:%SZ"),
+                record.level(),
+                record.target(),
+                message
+            ))
+        })
+        .level_for("vrc_research_bot", log::LevelFilter::Debug)
+        .format(|out, message, record| {
+            out.finish(format_args!(
+                "[{} {}]: {}",
+                chrono::Local::now().format("%Y-%m-%dT%H:%M:%SZ"),
+                record.level(),
+                message
+            ))
+        })
+        .chain(std::io::stdout());
+    base_conf.apply().ok();
+}
+
 #[tokio::main]
 async fn main() {
-    env_logger::Builder::from_default_env()
-        .format(|buf, record| {
-            let ts = buf.timestamp();
-            writeln!(buf, "[{} {}]: {}", ts, record.level(), record.args())
-        })
-        .init();
+    init_logger();
     let mut tokens = load_tokens();
     if tokens.discord_token == *"" {
         println!("Please type discord bot token here> ");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 // TODO: 各変数が目的にあった名前か確認する
 use chrono::{Timelike, Utc};
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use poise::serenity_prelude::{
     self as serenity,
     all::{ChannelId, Context, CreateMessage, EventHandler, GatewayIntents, Ready},
@@ -149,6 +149,7 @@ struct Handler;
 #[async_trait]
 impl EventHandler for Handler {
     async fn ready(&self, ctx: Context, _ready: Ready) {
+        info!("Discord bot is ready.");
         tokio::spawn(async move {
             loop {
                 let now = Utc::now();
@@ -293,6 +294,7 @@ async fn main() {
     init_logger();
     let mut tokens = load_tokens();
     if tokens.discord_token == *"" {
+        warn!("tokens.json is not found.");
         println!("Please type discord bot token here> ");
         std::io::stdin().read_line(&mut tokens.discord_token).ok();
         tokens.discord_token = tokens.discord_token.replace("\n", "");
@@ -317,6 +319,13 @@ async fn main() {
             .framework(framework)
             .await
     {
-        if (client.start().await).is_ok() {}
+        debug!("Initialized Discord bot.");
+        if (client.start().await).is_ok() {
+            info!("Discord bot is started successfully.");
+        } else {
+            error!("Discord bot was not started successfully.");
+        }
+    } else {
+        error!("Failed to initialize Discord bot.");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,7 +203,7 @@ impl EventHandler for Handler {
                                             .send_message(
                                                 &ctx.http,
                                                 CreateMessage::new().content(
-                                                    String::from("New release found!\n{}")
+                                                    String::from("New release found!\n")
                                                         + &new_cache.releases[i].url,
                                                 ),
                                             )


### PR DESCRIPTION
Fixed #25
# Abstract
Bot初期化時のログを追加するついでに、Log実装を変更
# Log実装変更の理由
env_loggerだとクレートごとにログレベルを分けるのが面倒くさそうだったため。（そもそもできるかわからない）